### PR TITLE
Make editor ui work inside egui windows.

### DIFF
--- a/egui_node_graph/src/editor_ui.rs
+++ b/egui_node_graph/src/editor_ui.rs
@@ -130,8 +130,10 @@ where
                         node_kind.user_data(),
                         |graph, node_id| node_kind.build_node(graph, node_id),
                     );
-                    self.node_positions
-                        .insert(new_node, cursor_pos - self.pan_zoom.pan);
+                    self.node_positions.insert(
+                        new_node, 
+                        cursor_pos - self.pan_zoom.pan - editor_rect.min.to_vec2()
+                    );
                     self.node_order.push(new_node);
 
                     should_close_node_finder = true;

--- a/egui_node_graph/src/editor_ui.rs
+++ b/egui_node_graph/src/editor_ui.rs
@@ -103,7 +103,7 @@ where
                     .selected_node
                     .map(|selected| selected == node_id)
                     .unwrap_or(false),
-                pan: self.pan_zoom.pan,
+                pan: self.pan_zoom.pan + editor_rect.min.to_vec2(),
             }
                 .show(ui, &self.user_state);
 

--- a/egui_node_graph/src/editor_ui.rs
+++ b/egui_node_graph/src/editor_ui.rs
@@ -156,16 +156,14 @@ where
         };
 
         if let Some((_, ref locator)) = self.connection_in_progress {
-            let painter = ctx.layer_painter(LayerId::background());
             let start_pos = port_locations[locator];
-            painter.line_segment([start_pos, cursor_pos], connection_stroke)
+            ui.painter().line_segment([start_pos, cursor_pos], connection_stroke)
         }
 
         for (input, output) in self.graph.iter_connections() {
-            let painter = ctx.layer_painter(LayerId::background());
             let src_pos = port_locations[&AnyParameterId::Output(output)];
             let dst_pos = port_locations[&AnyParameterId::Input(input)];
-            painter.line_segment([src_pos, dst_pos], connection_stroke);
+            ui.painter().line_segment([src_pos, dst_pos], connection_stroke);
         }
 
         /* Handle responses from drawing nodes */


### PR DESCRIPTION
Proposal to fix #4
Note, this would be a breaking change and will require users to pass in an `&ui` when calling the `draw_graph_editor()`