### PR TITLE
Fix #26 - use lambdas/a struct instead of macros

### DIFF
--- a/egui_node_graph_example/src/app.rs
+++ b/egui_node_graph_example/src/app.rs
@@ -142,7 +142,7 @@ impl NodeTemplateTrait for MyNodeTemplate {
         // The nodes are created empty by default. This function needs to take
         // care of creating the desired inputs and outputs based on the template
 
-        // We define some lambdas here to avoid boilerplate. Note that this is
+        // We define some closures here to avoid boilerplate. Note that this is
         // entirely optional.
         let input_scalar = |graph: &mut MyGraph, name: &str| {
             graph.add_input_param(
@@ -176,7 +176,7 @@ impl NodeTemplateTrait for MyNodeTemplate {
 
         match self {
             MyNodeTemplate::AddScalar => {
-                // The first input param doesn't use the lambda so we can comment
+                // The first input param doesn't use the closure so we can comment
                 // it in more detail.
                 graph.add_input_param(
                     node_id,

--- a/egui_node_graph_example/src/app.rs
+++ b/egui_node_graph_example/src/app.rs
@@ -397,7 +397,7 @@ pub fn evaluate_node(
     outputs_cache: &mut OutputsCache,
 ) -> anyhow::Result<MyValueType> {
     // To solve a similar problem as creating node types above, we define an
-    // Evaluator as a convenience. They may be overkill for this small example,
+    // Evaluator as a convenience. It may be overkill for this small example,
     // but something like this makes the code much more readable when the
     // number of nodes starts growing.
 


### PR DESCRIPTION
As discussed in #26 - using lambdas / structures instead of macros. I think this is much easier for someone to reason about at a glance, especially as it doesn't introduce any new syntax or semantics. The first block was trivial, but the second block required me to introduce a temporary `struct Evaluator` to hold all of the relevant state.

I think the first block is uncontentious, but the second one might be a bit harder of a sell due to the increase in LoC. I think it's worth it, but you might not 😅 