### PR TITLE
the background color of title for each node

### DIFF
--- a/egui_node_graph/src/editor_ui.rs
+++ b/egui_node_graph/src/editor_ui.rs
@@ -522,7 +522,7 @@ where
                 fill: self.graph[self.node_id]
                     .user_data
                     .titlebar_color(ui, self.node_id, self.graph, user_state)
-                    .unwrap_or(background_color.lighten(0.8)),
+                    .unwrap_or_else(|| background_color.lighten(0.8)),
                 stroke: Stroke::none(),
             });
 

--- a/egui_node_graph/src/editor_ui.rs
+++ b/egui_node_graph/src/editor_ui.rs
@@ -323,15 +323,12 @@ where
         let mut responses = Vec::new();
 
         let background_color;
-        let titlebar_color;
         let text_color;
         if ui.visuals().dark_mode {
             background_color = color_from_hex("#3f3f3f").unwrap();
-            titlebar_color = background_color.lighten(0.8);
             text_color = color_from_hex("#fefefe").unwrap();
         } else {
             background_color = color_from_hex("#ffffff").unwrap();
-            titlebar_color = background_color.lighten(0.8);
             text_color = color_from_hex("#505050").unwrap();
         }
 
@@ -522,7 +519,10 @@ where
             let titlebar = Shape::Rect(RectShape {
                 rect: titlebar_rect,
                 rounding,
-                fill: titlebar_color,
+                fill: self.graph[self.node_id]
+                    .user_data
+                    .titlebar_color(ui, self.node_id, self.graph, user_state)
+                    .unwrap_or(background_color.lighten(0.8)),
                 stroke: Stroke::none(),
             });
 

--- a/egui_node_graph/src/traits.rs
+++ b/egui_node_graph/src/traits.rs
@@ -43,6 +43,18 @@ where
     ) -> Vec<NodeResponse<Self::Response>>
     where
         Self::Response: UserResponseTrait;
+
+    /// Set background color on titlebar
+    /// If the return value is None, the default color is set.
+    fn titlebar_color(
+        &self,
+        _ui: &egui::Ui,
+        _node_id: NodeId,
+        _graph: &Graph<Self, Self::DataType, Self::ValueType>,
+        _user_state: &Self::UserState,
+    ) -> Option<egui::Color32> {
+        None
+    }
 }
 
 /// This trait can be implemented by any user type. The trait tells the library


### PR DESCRIPTION
In #33 
make it possible to specify the background color of title for each node

`titllebar_color()` returns None by default. If it is None, it will be the default color.
So I didn't implement it in example.