### PR TITLE
Fix some small stuff

### DIFF
--- a/egui_node_graph/src/editor_ui.rs
+++ b/egui_node_graph/src/editor_ui.rs
@@ -118,7 +118,7 @@ where
         /* Draw the node finder, if open */
         let mut should_close_node_finder = false;
         if let Some(ref mut node_finder) = self.node_finder {
-            let mut node_finder_area = Area::new("node_finder");
+            let mut node_finder_area = Area::new("node_finder").order(Order::Foreground);
             if let Some(pos) = node_finder.position {
                 node_finder_area = node_finder_area.current_pos(pos);
             }

--- a/egui_node_graph/src/editor_ui.rs
+++ b/egui_node_graph/src/editor_ui.rs
@@ -248,18 +248,15 @@ where
             self.connection_in_progress = None;
         }
 
-        if mouse.button_released(PointerButton::Secondary) && cursor_in_editor && !cursor_in_finder
-        {
+        if mouse.secondary_down() && cursor_in_editor && !cursor_in_finder {
             self.node_finder = Some(NodeFinder::new_at(cursor_pos));
         }
         if ui.ctx().input().key_pressed(Key::Escape) {
             self.node_finder = None;
         }
 
-        if r.dragged() {
-            if ui.ctx().input().pointer.middle_down() {
-                self.pan_zoom.pan += ui.ctx().input().pointer.delta();
-            }
+        if r.dragged() && ui.ctx().input().pointer.middle_down() {
+            self.pan_zoom.pan += ui.ctx().input().pointer.delta();
         }
 
         // Deselect and deactivate finder if the editor backround is clicked,

--- a/egui_node_graph/src/traits.rs
+++ b/egui_node_graph/src/traits.rs
@@ -21,7 +21,7 @@ pub trait DataTypeTrait<UserState>: PartialEq + Eq {
 
     /// The name of this datatype. Return type is specified as Cow<str> because
     /// some implementations will need to allocate a new string to provide an
-    /// answer while others won't. 
+    /// answer while others won't.
     ///
     /// ## Example (borrowed value)
     /// Use this when you can get the name of the datatype from its fields or as


### PR DESCRIPTION
Fixes panning outside of the editor area, and being able to open a new finder by clicking inside the finder window. Also makes it so the finder area is always on top. It seemed to disappear when clicking twice in a editor area for some reason.

Tested in my program and seems to work.