### PR TITLE
Make node finder search bar case insensitive

### DIFF
--- a/egui_node_graph/src/node_finder.rs
+++ b/egui_node_graph/src/node_finder.rs
@@ -68,7 +68,10 @@ where
                     .show(ui, |ui| {
                         for kind in all_kinds.all_kinds() {
                             let kind_name = kind.node_finder_label().to_string();
-                            if kind_name.to_lowercase().contains(self.query.to_lowercase().as_str()) {
+                            if kind_name
+                                .to_lowercase()
+                                .contains(self.query.to_lowercase().as_str())
+                            {
                                 if ui.selectable_label(false, kind_name).clicked() {
                                     submitted_archetype = Some(kind);
                                 } else if query_submit {

--- a/egui_node_graph/src/node_finder.rs
+++ b/egui_node_graph/src/node_finder.rs
@@ -68,7 +68,7 @@ where
                     .show(ui, |ui| {
                         for kind in all_kinds.all_kinds() {
                             let kind_name = kind.node_finder_label().to_string();
-                            if kind_name.contains(self.query.as_str()) {
+                            if kind_name.to_lowercase().contains(self.query.to_lowercase().as_str()) {
                                 if ui.selectable_label(false, kind_name).clicked() {
                                     submitted_archetype = Some(kind);
                                 } else if query_submit {


### PR DESCRIPTION
Just a simple quality of life feature to make the node finder search bar case insensitive by default.
I'm fairly new to rust and open-source in general but excited to follow the development of blackjack and maybe contribute in the future. Really cool idea.

<img width="282" alt="image" src="https://user-images.githubusercontent.com/8052061/175546588-49afeb86-fd93-4ce5-9cd5-b754f7cb1ae7.png">
