### PR TITLE
Add `UserState` to `build_node`

### DIFF
--- a/egui_node_graph/src/editor_ui.rs
+++ b/egui_node_graph/src/editor_ui.rs
@@ -68,8 +68,12 @@ where
     >,
     UserResponse: UserResponseTrait,
     ValueType: WidgetValueTrait<Response = UserResponse>,
-    NodeTemplate:
-        NodeTemplateTrait<NodeData = NodeData, DataType = DataType, ValueType = ValueType>,
+    NodeTemplate: NodeTemplateTrait<
+        NodeData = NodeData,
+        DataType = DataType,
+        ValueType = ValueType,
+        UserState = UserState,
+    >,
     DataType: DataTypeTrait<UserState>,
 {
     #[must_use]
@@ -142,7 +146,7 @@ where
                     let new_node = self.graph.add_node(
                         node_kind.node_graph_label(),
                         node_kind.user_data(),
-                        |graph, node_id| node_kind.build_node(graph, node_id),
+                        |graph, node_id| node_kind.build_node(graph, &self.user_state, node_id),
                     );
                     self.node_positions.insert(
                         new_node,

--- a/egui_node_graph/src/traits.rs
+++ b/egui_node_graph/src/traits.rs
@@ -108,6 +108,8 @@ pub trait NodeTemplateTrait: Clone {
     type DataType;
     /// Must be set to the custom user `ValueType` type
     type ValueType;
+    /// Must be set to the custom user `UserState` type
+    type UserState;
 
     /// Returns a descriptive name for the node kind, used in the node finder.
     fn node_finder_label(&self) -> &str;
@@ -124,6 +126,7 @@ pub trait NodeTemplateTrait: Clone {
     fn build_node(
         &self,
         graph: &mut Graph<Self::NodeData, Self::DataType, Self::ValueType>,
+        user_state: &Self::UserState,
         node_id: NodeId,
     );
 }

--- a/egui_node_graph_example/src/app.rs
+++ b/egui_node_graph_example/src/app.rs
@@ -111,6 +111,7 @@ impl NodeTemplateTrait for MyNodeTemplate {
     type NodeData = MyNodeData;
     type DataType = MyDataType;
     type ValueType = MyValueType;
+    type UserState = MyGraphState;
 
     fn node_finder_label(&self) -> &str {
         match self {
@@ -137,6 +138,7 @@ impl NodeTemplateTrait for MyNodeTemplate {
     fn build_node(
         &self,
         graph: &mut Graph<Self::NodeData, Self::DataType, Self::ValueType>,
+        _user_state: &Self::UserState,
         node_id: NodeId,
     ) {
         // The nodes are created empty by default. This function needs to take


### PR DESCRIPTION
Sometimes the `NodeTemplate` cannot store all the information you need to create a new node (may be too expensive to copy all that data around, or simply can't own the data). In those cases, it makes sense to store some sort of id or handle inside the `NodeTemplate` and use that to index into a structure holding the actual data.

To enable this pattern, the `user_state` is now passed as a parameter to `build_node`. This is a breaking change, but not a huge one: Old implementations can simply ignore the new parameter, and the compiler should guide users to the issue when updating. It still was deemed necessary because there's no other way to access graph-global data in `build_node`.