### PR TITLE
Bump egui to 0.19.0

### DIFF
--- a/egui_node_graph/Cargo.toml
+++ b/egui_node_graph/Cargo.toml
@@ -15,7 +15,7 @@ workspace = ".."
 persistence = ["serde", "slotmap/serde", "smallvec/serde", "egui/persistence"]
 
 [dependencies]
-egui = { version = "0.18" }
+egui = { version = "0.19.0" }
 slotmap = { version = "1.0" }
 smallvec = { version = "1.7.0" }
 serde = { version = "1.0", optional = true, features = ["derive"] }

--- a/egui_node_graph_example/Cargo.toml
+++ b/egui_node_graph_example/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = "1.56"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-eframe = "0.18.0"
+eframe = "0.19.0"
 egui_node_graph = { path = "../egui_node_graph" }
 anyhow = "1.0"
 


### PR DESCRIPTION
Bump version for library and example. I ran the workspace tests and example, and everything looks good.

Closes  #55