### PR TITLE
Fix/incompatible port snap

### DIFF
--- a/egui_node_graph/src/editor_ui.rs
+++ b/egui_node_graph/src/editor_ui.rs
@@ -292,7 +292,7 @@ where
                     self.node_order.retain(|id| *id != *node_id);
                 }
                 NodeResponse::DisconnectEvent { input, output } => {
-                    let other_node = self.graph.get_input(*input).node();
+                    let other_node = self.graph.get_output(*output).node;
                     self.graph.remove_connection(*input);
                     self.connection_in_progress =
                         Some((other_node, AnyParameterId::Output(*output)));


### PR DESCRIPTION
This takes care of the second half of https://github.com/setzer22/egui_node_graph/issues/54, where ports snapped to incompatible colors even when the connection was not possible. As discussed there, once we allow custom rules for connections between different colors (this was being worked on as part of #30) we will need to adapt this logic from using `==` to using the custom comparison function.

I also took care of a bug where removing an existing connection and re-wiring it to the same port would not work. This is now fixed.