### PR TITLE
A couple minor bugfixes

### DIFF
--- a/egui_node_graph/src/editor_ui.rs
+++ b/egui_node_graph/src/editor_ui.rs
@@ -112,7 +112,7 @@ where
 
         // Gets filled with the node metrics as they are drawn
         let mut port_locations = PortLocations::new();
-        let mut node_sizes = NodeRects::new();
+        let mut node_rects = NodeRects::new();
 
         // The responses returned from node drawing have side effects that are best
         // executed at the end of this function.
@@ -138,7 +138,7 @@ where
                 position: self.node_positions.get_mut(node_id).unwrap(),
                 graph: &mut self.graph,
                 port_locations: &mut port_locations,
-                node_rects: &mut node_sizes,
+                node_rects: &mut node_rects,
                 node_id,
                 ongoing_drag: self.connection_in_progress,
                 selected: self
@@ -365,7 +365,7 @@ where
                 Stroke::new(3.0, stroke_color),
             );
 
-            self.selected_nodes = node_sizes
+            self.selected_nodes = node_rects
                 .into_iter()
                 .filter_map(|(node_id, rect)| {
                     if selection_rect.intersects(rect) {
@@ -391,7 +391,7 @@ where
             self.connection_in_progress = None;
         }
 
-        if mouse.secondary_down() && cursor_in_editor && !cursor_in_finder {
+        if mouse.secondary_clicked() && cursor_in_editor && !cursor_in_finder {
             self.node_finder = Some(NodeFinder::new_at(cursor_pos));
         }
         if ui.ctx().input().key_pressed(Key::Escape) {
@@ -409,7 +409,7 @@ where
             self.node_finder = None;
         }
 
-        if drag_started_on_background {
+        if drag_started_on_background && mouse.primary_down() {
             self.ongoing_box_selection = Some(cursor_pos);
         }
         if mouse.primary_released() || drag_released_on_background {

--- a/egui_node_graph/src/editor_ui.rs
+++ b/egui_node_graph/src/editor_ui.rs
@@ -195,7 +195,7 @@ where
                     should_close_node_finder = true;
                     delayed_responses.push(NodeResponse::CreatedNode(new_node));
                 }
-                let finder_rect = ui.max_rect();
+                let finder_rect = ui.min_rect();
                 // If the cursor is not in the main editor, check if the cursor is in the finder
                 // if the cursor is in the finder, then we can consider that also in the editor.
                 if finder_rect.contains(cursor_pos) {
@@ -401,7 +401,7 @@ where
             self.connection_in_progress = None;
         }
 
-        if mouse.secondary_clicked() && cursor_in_editor && !cursor_in_finder {
+        if mouse.secondary_released() && cursor_in_editor && !cursor_in_finder {
             self.node_finder = Some(NodeFinder::new_at(cursor_pos));
         }
         if ui.ctx().input().key_pressed(Key::Escape) {

--- a/egui_node_graph/src/editor_ui.rs
+++ b/egui_node_graph/src/editor_ui.rs
@@ -196,9 +196,9 @@ where
                     delayed_responses.push(NodeResponse::CreatedNode(new_node));
                 }
                 let finder_rect = ui.max_rect();
-                // If the cursor is not in the main editor, check if the cursor *is* in the finder
+                // If the cursor is not in the main editor, check if the cursor is in the finder
                 // if the cursor is in the finder, then we can consider that also in the editor.
-                if !cursor_in_editor && finder_rect.contains(cursor_pos) {
+                if finder_rect.contains(cursor_pos) {
                     cursor_in_editor = true;
                     cursor_in_finder = true;
                 }

--- a/egui_node_graph/src/editor_ui.rs
+++ b/egui_node_graph/src/editor_ui.rs
@@ -51,7 +51,15 @@ pub enum NodeResponse<UserResponse: UserResponseTrait, NodeData: NodeDataTrait> 
 /// user code react to specific events that happened when drawing the graph.
 #[derive(Clone, Debug)]
 pub struct GraphResponse<UserResponse: UserResponseTrait, NodeData: NodeDataTrait> {
+    /// Events that occurred during this frame of rendering the graph. Check the
+    /// [`UserResponse`] type for a description of each event.
     pub node_responses: Vec<NodeResponse<UserResponse, NodeData>>,
+    /// Is the mouse currently hovering the graph editor? Note that the node
+    /// finder is considered part of the graph editor, even when it floats
+    /// outside the graph editor rect.
+    pub cursor_in_editor: bool,
+    /// Is the mouse currently hovering the node finder?
+    pub cursor_in_finder: bool,
 }
 impl<UserResponse: UserResponseTrait, NodeData: NodeDataTrait> Default
     for GraphResponse<UserResponse, NodeData>
@@ -59,6 +67,8 @@ impl<UserResponse: UserResponseTrait, NodeData: NodeDataTrait> Default
     fn default() -> Self {
         Self {
             node_responses: Default::default(),
+            cursor_in_editor: false,
+            cursor_in_finder: false,
         }
     }
 }
@@ -418,6 +428,8 @@ where
 
         GraphResponse {
             node_responses: delayed_responses,
+            cursor_in_editor,
+            cursor_in_finder,
         }
     }
 }

--- a/egui_node_graph/src/node_finder.rs
+++ b/egui_node_graph/src/node_finder.rs
@@ -10,7 +10,7 @@ pub struct NodeFinder<NodeTemplate> {
     pub query: String,
     /// Reset every frame. When set, the node finder will be moved at that position
     pub position: Option<Pos2>,
-    pub just_spawned: bool,
+    pub frames_since_spawned: u32,
     _phantom: PhantomData<NodeTemplate>,
 }
 
@@ -22,7 +22,7 @@ where
         NodeFinder {
             query: "".into(),
             position: Some(pos),
-            just_spawned: true,
+            frames_since_spawned: 0,
             _phantom: Default::default(),
         }
     }
@@ -58,9 +58,13 @@ where
         frame.show(ui, |ui| {
             ui.vertical(|ui| {
                 let resp = ui.text_edit_singleline(&mut self.query);
-                if self.just_spawned {
+                // HACK: The request_focus call doesn't succeed if we do it
+                // right after spawning the node finder, so we do it for a few
+                // frames until it works. This is could be a bug inside egui.
+                // The value 3 is the smallest number of frames that works.
+                if self.frames_since_spawned <= 3 {
                     resp.request_focus();
-                    self.just_spawned = false;
+                    self.frames_since_spawned += 1;
                 }
 
                 let mut query_submit = resp.lost_focus() && ui.input().key_down(Key::Enter);

--- a/egui_node_graph/src/node_finder.rs
+++ b/egui_node_graph/src/node_finder.rs
@@ -65,23 +65,31 @@ where
 
                 let mut query_submit = resp.lost_focus() && ui.input().key_down(Key::Enter);
 
+                let max_height = ui.input().screen_rect.height() * 0.5;
+                let scroll_area_width = resp.rect.width() - 30.0;
+
                 Frame::default()
                     .inner_margin(vec2(10.0, 10.0))
                     .show(ui, |ui| {
-                        for kind in all_kinds.all_kinds() {
-                            let kind_name = kind.node_finder_label(user_state).to_string();
-                            if kind_name
-                                .to_lowercase()
-                                .contains(self.query.to_lowercase().as_str())
-                            {
-                                if ui.selectable_label(false, kind_name).clicked() {
-                                    submitted_archetype = Some(kind);
-                                } else if query_submit {
-                                    submitted_archetype = Some(kind);
-                                    query_submit = false;
+                        ScrollArea::vertical()
+                            .max_height(max_height)
+                            .show(ui, |ui| {
+                                ui.set_width(scroll_area_width);
+                                for kind in all_kinds.all_kinds() {
+                                    let kind_name = kind.node_finder_label(user_state).to_string();
+                                    if kind_name
+                                        .to_lowercase()
+                                        .contains(self.query.to_lowercase().as_str())
+                                    {
+                                        if ui.selectable_label(false, kind_name).clicked() {
+                                            submitted_archetype = Some(kind);
+                                        } else if query_submit {
+                                            submitted_archetype = Some(kind);
+                                            query_submit = false;
+                                        }
+                                    }
                                 }
-                            }
-                        }
+                            });
                     });
             });
         });

--- a/egui_node_graph/src/node_finder.rs
+++ b/egui_node_graph/src/node_finder.rs
@@ -10,7 +10,7 @@ pub struct NodeFinder<NodeTemplate> {
     pub query: String,
     /// Reset every frame. When set, the node finder will be moved at that position
     pub position: Option<Pos2>,
-    pub frames_since_spawned: u32,
+    pub just_spawned: bool,
     _phantom: PhantomData<NodeTemplate>,
 }
 
@@ -22,7 +22,7 @@ where
         NodeFinder {
             query: "".into(),
             position: Some(pos),
-            frames_since_spawned: 0,
+            just_spawned: true,
             _phantom: Default::default(),
         }
     }
@@ -58,13 +58,9 @@ where
         frame.show(ui, |ui| {
             ui.vertical(|ui| {
                 let resp = ui.text_edit_singleline(&mut self.query);
-                // HACK: The request_focus call doesn't succeed if we do it
-                // right after spawning the node finder, so we do it for a few
-                // frames until it works. This is could be a bug inside egui.
-                // The value 3 is the smallest number of frames that works.
-                if self.frames_since_spawned <= 3 {
+                if self.just_spawned {
                     resp.request_focus();
-                    self.frames_since_spawned += 1;
+                    self.just_spawned = false;
                 }
 
                 let mut query_submit = resp.lost_focus() && ui.input().key_down(Key::Enter);


### PR DESCRIPTION
- Spawn the node finder on "mouse_click" rather than "mouse_down".
- Only create a box selection when the primary button is held.
- Add a scroll bar for when an application registers too many nodes in the node finder.