### PR TITLE
Node can decide whether it can be deleted

### DIFF
--- a/egui_node_graph/src/editor_ui.rs
+++ b/egui_node_graph/src/editor_ui.rs
@@ -771,9 +771,16 @@ where
         // --- Interaction ---
 
         // Titlebar buttons
-        if Self::close_button(ui, outer_rect).clicked() {
-            responses.push(NodeResponse::DeleteNodeUi(self.node_id));
-        };
+        let can_delete = self.graph.nodes[self.node_id].user_data.can_delete(
+            self.node_id,
+            self.graph,
+            user_state,
+        );
+        if can_delete {
+            if Self::close_button(ui, outer_rect).clicked() {
+                responses.push(NodeResponse::DeleteNodeUi(self.node_id));
+            };
+        }
 
         let window_response = ui.interact(
             outer_rect,

--- a/egui_node_graph/src/editor_ui.rs
+++ b/egui_node_graph/src/editor_ui.rs
@@ -776,11 +776,10 @@ where
             self.graph,
             user_state,
         );
-        if can_delete {
-            if Self::close_button(ui, outer_rect).clicked() {
-                responses.push(NodeResponse::DeleteNodeUi(self.node_id));
-            };
-        }
+
+        if can_delete && Self::close_button(ui, outer_rect).clicked() {
+            responses.push(NodeResponse::DeleteNodeUi(self.node_id));
+        };
 
         let window_response = ui.interact(
             outer_rect,

--- a/egui_node_graph/src/traits.rs
+++ b/egui_node_graph/src/traits.rs
@@ -102,6 +102,15 @@ where
     ) -> Option<egui::Color32> {
         None
     }
+
+    fn can_delete(
+        &self,
+        _node_id: NodeId,
+        _graph: &Graph<Self, Self::DataType, Self::ValueType>,
+        _user_state: &mut Self::UserState,
+    ) -> bool {
+        true
+    }
 }
 
 /// This trait can be implemented by any user type. The trait tells the library


### PR DESCRIPTION
Add method `can_delete` to NodeDataTrait.

The close button on the node widget will not be shown if `can_delete` returns false.