### PR TITLE
Update to egui 0.21 & fix the interaction bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+.idea

--- a/egui_node_graph/Cargo.toml
+++ b/egui_node_graph/Cargo.toml
@@ -15,8 +15,8 @@ workspace = ".."
 persistence = ["serde", "slotmap/serde", "smallvec/serde", "egui/persistence"]
 
 [dependencies]
-egui = { version = "0.19.0" }
+egui = { version = "0.21.0" }
 slotmap = { version = "1.0" }
-smallvec = { version = "1.7.0" }
+smallvec = { version = "1.10.0" }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 thiserror = "1.0"

--- a/egui_node_graph/src/editor_ui.rs
+++ b/egui_node_graph/src/editor_ui.rs
@@ -116,7 +116,9 @@ where
         let editor_rect = ui.max_rect();
         ui.allocate_rect(editor_rect, Sense::hover());
 
-        let cursor_pos = ui.ctx().input().pointer.hover_pos().unwrap_or(Pos2::ZERO);
+        let cursor_pos = ui
+            .ctx()
+            .input(|i| i.pointer.hover_pos().unwrap_or(Pos2::ZERO));
         let mut cursor_in_editor = editor_rect.contains(cursor_pos);
         let mut cursor_in_finder = false;
 
@@ -395,7 +397,7 @@ where
         /* Mouse input handling */
 
         // This locks the context, so don't hold on to it for too long.
-        let mouse = &ui.ctx().input().pointer;
+        let mouse = &ui.ctx().input(|i| i.pointer.clone());
 
         if mouse.any_released() && self.connection_in_progress.is_some() {
             self.connection_in_progress = None;
@@ -404,12 +406,12 @@ where
         if mouse.secondary_released() && cursor_in_editor && !cursor_in_finder {
             self.node_finder = Some(NodeFinder::new_at(cursor_pos));
         }
-        if ui.ctx().input().key_pressed(Key::Escape) {
+        if ui.ctx().input(|i| i.key_pressed(Key::Escape)) {
             self.node_finder = None;
         }
 
-        if r.dragged() && ui.ctx().input().pointer.middle_down() {
-            self.pan_zoom.pan += ui.ctx().input().pointer.delta();
+        if r.dragged() && ui.ctx().input(|i| i.pointer.middle_down()) {
+            self.pan_zoom.pan += ui.ctx().input(|i| i.pointer.delta());
         }
 
         // Deselect and deactivate finder if the editor backround is clicked,
@@ -628,7 +630,7 @@ where
                 port_type.data_type_color(user_state)
             };
             ui.painter()
-                .circle(port_rect.center(), 5.0, port_color, Stroke::none());
+                .circle(port_rect.center(), 5.0, port_color, Stroke::NONE);
 
             if resp.drag_started() {
                 if is_connected_input {
@@ -650,7 +652,7 @@ where
                     // Don't allow self-loops
                     if graph.any_param_type(origin_param).unwrap() == port_type
                         && close_enough
-                        && ui.input().pointer.any_released()
+                        && ui.input(|i| i.pointer.any_released())
                     {
                         match (param_id, origin_param) {
                             (AnyParameterId::Input(input), AnyParameterId::Output(output))
@@ -734,7 +736,7 @@ where
                     .user_data
                     .titlebar_color(ui, self.node_id, self.graph, user_state)
                     .unwrap_or_else(|| background_color.lighten(0.8)),
-                stroke: Stroke::none(),
+                stroke: Stroke::NONE,
             });
 
             let body_rect = Rect::from_min_size(
@@ -745,7 +747,7 @@ where
                 rect: body_rect,
                 rounding: Rounding::none(),
                 fill: background_color,
-                stroke: Stroke::none(),
+                stroke: Stroke::NONE,
             });
 
             let bottom_body_rect = Rect::from_min_size(
@@ -756,7 +758,7 @@ where
                 rect: bottom_body_rect,
                 rounding,
                 fill: background_color,
-                stroke: Stroke::none(),
+                stroke: Stroke::NONE,
             });
 
             let node_rect = titlebar_rect.union(body_rect).union(bottom_body_rect);
@@ -765,7 +767,7 @@ where
                     rect: node_rect.expand(1.0),
                     rounding,
                     fill: Color32::WHITE.lighten(0.8),
-                    stroke: Stroke::none(),
+                    stroke: Stroke::NONE,
                 })
             } else {
                 Shape::Noop

--- a/egui_node_graph/src/node_finder.rs
+++ b/egui_node_graph/src/node_finder.rs
@@ -63,9 +63,9 @@ where
                     self.just_spawned = false;
                 }
 
-                let mut query_submit = resp.lost_focus() && ui.input().key_down(Key::Enter);
+                let mut query_submit = resp.lost_focus() && ui.input(|i| i.key_pressed(Key::Enter));
 
-                let max_height = ui.input().screen_rect.height() * 0.5;
+                let max_height = ui.input(|i| i.screen_rect.height());
                 let scroll_area_width = resp.rect.width() - 30.0;
 
                 Frame::default()

--- a/egui_node_graph/src/node_finder.rs
+++ b/egui_node_graph/src/node_finder.rs
@@ -65,7 +65,7 @@ where
 
                 let mut query_submit = resp.lost_focus() && ui.input(|i| i.key_pressed(Key::Enter));
 
-                let max_height = ui.input(|i| i.screen_rect.height());
+                let max_height = ui.input(|i| i.screen_rect.height() * 0.5);
                 let scroll_area_width = resp.rect.width() - 30.0;
 
                 Frame::default()

--- a/egui_node_graph_example/Cargo.toml
+++ b/egui_node_graph_example/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = "1.56"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-eframe = "0.19.0"
+eframe = "0.21.0"
 egui_node_graph = { path = "../egui_node_graph" }
 anyhow = "1.0"
 serde = { version = "1.0", optional = true }

--- a/egui_node_graph_example/src/main.rs
+++ b/egui_node_graph_example/src/main.rs
@@ -19,5 +19,6 @@ fn main() {
             #[cfg(not(feature = "persistence"))]
             Box::new(egui_node_graph_example::NodeGraphExample::default())
         }),
-    );
+    )
+    .expect("Failed to run native example");
 }


### PR DESCRIPTION
Trying a fix here for #79 

So, I'm pretty sure https://github.com/emilk/egui/pull/2244 broke the movement etc. Because the hover interaction never takes place on the `responses` for areas covered by other widgets. You can see this by debugging the overlapping widgets with styles.  Maybe there is some way to tweak the layers / order of widgets, but dunno. So the solution:

- change the order of  `allocate_rect` for the background. Before the nodes.
- And to fix the nodes themselves, call `ui.interact` before adding the contets.

Perhaps there is a better fix, ~~and I'm not sure if this breaks the dynamic rect size of the widgets~~, but the example works.

This could at least point someone more knowledgeable towards a better direction so we can update to newer egui.