### PR TITLE
add output ui

### DIFF
--- a/egui_node_graph/src/editor_ui.rs
+++ b/egui_node_graph/src/editor_ui.rs
@@ -610,7 +610,12 @@ where
             let outputs = self.graph[self.node_id].outputs.clone();
             for (param_name, _param) in outputs {
                 let height_before = ui.min_rect().bottom();
-                ui.label(&param_name);
+                responses.extend(
+                    self.graph[self.node_id]
+                        .user_data
+                        .output_ui(ui, self.node_id, self.graph, user_state, &param_name)
+                        .into_iter(),
+                );
                 let height_after = ui.min_rect().bottom();
                 output_port_heights.push((height_before + height_after) / 2.0);
             }

--- a/egui_node_graph/src/traits.rs
+++ b/egui_node_graph/src/traits.rs
@@ -127,6 +127,25 @@ where
         Default::default()
     }
 
+    /// UI to draw for each output
+    ///
+    /// Defaults to showing param_name as a simple label.
+    fn output_ui(
+        &self,
+        ui: &mut egui::Ui,
+        _node_id: NodeId,
+        _graph: &Graph<Self, Self::DataType, Self::ValueType>,
+        _user_state: &mut Self::UserState,
+        param_name: &str,
+    ) -> Vec<NodeResponse<Self::Response, Self>>
+    where
+        Self::Response: UserResponseTrait,
+    {
+        ui.label(param_name);
+
+        Default::default()
+    }
+
     /// Set background color on titlebar
     /// If the return value is None, the default color is set.
     fn titlebar_color(


### PR DESCRIPTION
This method draws the UI for each of the outputs corresponding to the node. Defaults to the label that was the previous hard-coded behavior. The default impl also means this isn't a breaking change.