### PR TITLE
Add top bar UI

### DIFF
--- a/egui_node_graph/src/editor_ui.rs
+++ b/egui_node_graph/src/editor_ui.rs
@@ -527,6 +527,12 @@ where
                         .text_style(TextStyle::Button)
                         .color(text_color),
                 ));
+                responses.extend(
+                    self.graph[self.node_id]
+                        .user_data
+                        .top_bar_ui(ui, self.node_id, self.graph, user_state)
+                        .into_iter(),
+                );
                 ui.add_space(8.0); // The size of the little cross icon
             });
             ui.add_space(margin.y);

--- a/egui_node_graph/src/traits.rs
+++ b/egui_node_graph/src/traits.rs
@@ -91,6 +91,20 @@ where
     where
         Self::Response: UserResponseTrait;
 
+    // UI to draw on the top bar of the node.
+    fn top_bar_ui(
+        &self,
+        _ui: &mut egui::Ui,
+        _node_id: NodeId,
+        _graph: &Graph<Self, Self::DataType, Self::ValueType>,
+        _user_state: &mut Self::UserState,
+    ) -> Vec<NodeResponse<Self::Response, Self>>
+    where
+        Self::Response: UserResponseTrait,
+    {
+        Default::default()
+    }
+
     /// Set background color on titlebar
     /// If the return value is None, the default color is set.
     fn titlebar_color(


### PR DESCRIPTION
Users can specify UI that will be added to the top bar of a node via the new `top_bar_ui` method in `NodeDataTrait`. A default definition is provided because it's not core to the functionality and so as to avoid unnecessarily breaking existing programs.