### PR TITLE
custom separators

### DIFF
--- a/egui_node_graph/src/editor_ui.rs
+++ b/egui_node_graph/src/editor_ui.rs
@@ -600,6 +600,13 @@ where
                         responses.extend(node_responses.into_iter().map(NodeResponse::User));
                     }
 
+                    self.graph[self.node_id].user_data.separator(
+                        ui,
+                        self.node_id,
+                        self.graph,
+                        user_state,
+                    );
+
                     self.graph[param_id].value = value;
 
                     let height_after = ui.min_rect().bottom();
@@ -616,6 +623,14 @@ where
                         .output_ui(ui, self.node_id, self.graph, user_state, &param_name)
                         .into_iter(),
                 );
+
+                self.graph[self.node_id].user_data.separator(
+                    ui,
+                    self.node_id,
+                    self.graph,
+                    user_state,
+                );
+
                 let height_after = ui.min_rect().bottom();
                 output_port_heights.push((height_before + height_after) / 2.0);
             }

--- a/egui_node_graph/src/editor_ui.rs
+++ b/egui_node_graph/src/editor_ui.rs
@@ -603,6 +603,7 @@ where
                     self.graph[self.node_id].user_data.separator(
                         ui,
                         self.node_id,
+                        AnyParameterId::Input(param_id),
                         self.graph,
                         user_state,
                     );
@@ -615,7 +616,7 @@ where
             }
 
             let outputs = self.graph[self.node_id].outputs.clone();
-            for (param_name, _param) in outputs {
+            for (param_name, param_id) in outputs {
                 let height_before = ui.min_rect().bottom();
                 responses.extend(
                     self.graph[self.node_id]
@@ -627,6 +628,7 @@ where
                 self.graph[self.node_id].user_data.separator(
                     ui,
                     self.node_id,
+                    AnyParameterId::Output(param_id),
                     self.graph,
                     user_state,
                 );

--- a/egui_node_graph/src/traits.rs
+++ b/egui_node_graph/src/traits.rs
@@ -113,7 +113,7 @@ where
     where
         Self::Response: UserResponseTrait;
 
-    // UI to draw on the top bar of the node.
+    /// UI to draw on the top bar of the node.
     fn top_bar_ui(
         &self,
         _ui: &mut egui::Ui,

--- a/egui_node_graph/src/traits.rs
+++ b/egui_node_graph/src/traits.rs
@@ -162,13 +162,15 @@ where
     ///
     /// Invoked between inputs, outputs and bottom UI. Useful for
     /// complicated UIs that start to lose structure without explicit
-    /// separators.
+    /// separators. The `param_id` argument is the id of input or output
+    /// *preceeding* the separator.
     ///
     /// Default implementation does nothing.
     fn separator(
         &self,
         _ui: &mut egui::Ui,
         _node_id: NodeId,
+        _param_id: AnyParameterId,
         _graph: &Graph<Self, Self::DataType, Self::ValueType>,
         _user_state: &mut Self::UserState,
     ) {

--- a/egui_node_graph/src/traits.rs
+++ b/egui_node_graph/src/traits.rs
@@ -158,6 +158,22 @@ where
         None
     }
 
+    /// Separator to put between elements in the node.
+    ///
+    /// Invoked between inputs, outputs and bottom UI. Useful for
+    /// complicated UIs that start to lose structure without explicit
+    /// separators.
+    ///
+    /// Default implementation does nothing.
+    fn separator(
+        &self,
+        _ui: &mut egui::Ui,
+        _node_id: NodeId,
+        _graph: &Graph<Self, Self::DataType, Self::ValueType>,
+        _user_state: &mut Self::UserState,
+    ) {
+    }
+
     fn can_delete(
         &self,
         _node_id: NodeId,


### PR DESCRIPTION
Complex UIs for inputs/outputs/bottom tend to blend together so it's userfult to be able to define a separator between those child-UIs easily.

I was wondering whether to only pass `&mut egui::Ui` for simplicity, but in the end I think it's better to provide a more capable API consistent with other methods considering that there's basically no cost to that, even if I don't see a specific use-case right now.

Also, fixed a missing doc comment.