### PR TITLE
draw_graph_editor: fix cursor_in_editor

### DIFF
--- a/egui_node_graph/src/editor_ui.rs
+++ b/egui_node_graph/src/editor_ui.rs
@@ -114,12 +114,12 @@ where
         // (so for windows it will use up to the resizeably set limit
         // and for a Panel it will fill it completely)
         let editor_rect = ui.max_rect();
-        ui.allocate_rect(editor_rect, Sense::hover());
+        let resp = ui.allocate_rect(editor_rect, Sense::hover());
 
         let cursor_pos = ui
             .ctx()
             .input(|i| i.pointer.hover_pos().unwrap_or(Pos2::ZERO));
-        let mut cursor_in_editor = editor_rect.contains(cursor_pos);
+        let mut cursor_in_editor = resp.hovered();
         let mut cursor_in_finder = false;
 
         // Gets filled with the node metrics as they are drawn


### PR DESCRIPTION
Previously the editor assumed that if the `editor_rect` contained the cursor, then the editor should act like it is hovered. This works as long as the editor is the only widget in the central panel, but it broke when interacting with windows.

If a window was covering some part of the editor widget:
1. You could open the node finder while hovering the window, which is terrible for interacting with widgets within that window.
2. You could not close the node finder by clicking on the window (this click was considered neither a background click, nor an out-of-editor click).

This is fixed by using egui sense to detect hover, which will automatically handle any widgets overlapping the editor.