### PR TITLE
Allow inserting responses in draw_graph_editor

### DIFF
--- a/egui_node_graph/src/editor_ui.rs
+++ b/egui_node_graph/src/editor_ui.rs
@@ -111,6 +111,7 @@ where
         ui: &mut Ui,
         all_kinds: impl NodeTemplateIter<Item = NodeTemplate>,
         user_state: &mut UserState,
+        prepend_responses: Vec<NodeResponse<UserResponse, NodeData>>,
     ) -> GraphResponse<UserResponse, NodeData> {
         // This causes the graph editor to use as much free space as it can.
         // (so for windows it will use up to the resizeably set limit
@@ -130,7 +131,7 @@ where
 
         // The responses returned from node drawing have side effects that are best
         // executed at the end of this function.
-        let mut delayed_responses: Vec<NodeResponse<UserResponse, NodeData>> = vec![];
+        let mut delayed_responses: Vec<NodeResponse<UserResponse, NodeData>> = prepend_responses;
 
         // Used to detect when the background was clicked
         let mut click_on_background = false;

--- a/egui_node_graph_example/src/app.rs
+++ b/egui_node_graph_example/src/app.rs
@@ -417,8 +417,12 @@ impl eframe::App for NodeGraphExample {
         });
         let graph_response = egui::CentralPanel::default()
             .show(ctx, |ui| {
-                self.state
-                    .draw_graph_editor(ui, AllMyNodeTemplates, &mut self.user_state)
+                self.state.draw_graph_editor(
+                    ui,
+                    AllMyNodeTemplates,
+                    &mut self.user_state,
+                    Vec::default(),
+                )
             })
             .inner;
         for node_response in graph_response.node_responses {


### PR DESCRIPTION
This allows a user to trigger an event externally as if it was created by UI. For example, to remove a node one just needs to insert a `NodeRespone::DeleteNodeUi(..)`. Without this feature you need to remove the node from the graph *and* adjust the internals of `GraphEditorState`.