### PR TITLE
Bump egui to 0.22

### DIFF
--- a/egui_node_graph/Cargo.toml
+++ b/egui_node_graph/Cargo.toml
@@ -15,7 +15,7 @@ workspace = ".."
 persistence = ["serde", "slotmap/serde", "smallvec/serde", "egui/persistence"]
 
 [dependencies]
-egui = { version = "0.21.0" }
+egui = { version = "0.22.0" }
 slotmap = { version = "1.0" }
 smallvec = { version = "1.10.0" }
 serde = { version = "1.0", optional = true, features = ["derive"] }

--- a/egui_node_graph_example/Cargo.toml
+++ b/egui_node_graph_example/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = "1.56"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-eframe = "0.21.0"
+eframe = "0.22.0"
 egui_node_graph = { path = "../egui_node_graph" }
 anyhow = "1.0"
 serde = { version = "1.0", optional = true }


### PR DESCRIPTION
Something changed somewhere, if you open the node finder near the edge of window it doesn't get shrunk (meaning its top-left corner isn't at the pointer position) until some input event updates it.