### PR TITLE
Add ParamId to output_ui & value_widget{,_connected} methods

### DIFF
--- a/egui_node_graph/src/editor_ui.rs
+++ b/egui_node_graph/src/editor_ui.rs
@@ -585,6 +585,7 @@ where
                         let node_responses = value.value_widget_connected(
                             &param_name,
                             self.node_id,
+                            param_id,
                             ui,
                             user_state,
                             &self.graph[self.node_id].user_data,
@@ -595,6 +596,7 @@ where
                         let node_responses = value.value_widget(
                             &param_name,
                             self.node_id,
+                            param_id,
                             ui,
                             user_state,
                             &self.graph[self.node_id].user_data,

--- a/egui_node_graph/src/editor_ui.rs
+++ b/egui_node_graph/src/editor_ui.rs
@@ -624,7 +624,14 @@ where
                 responses.extend(
                     self.graph[self.node_id]
                         .user_data
-                        .output_ui(ui, self.node_id, self.graph, user_state, &param_name)
+                        .output_ui(
+                            ui,
+                            self.node_id,
+                            self.graph,
+                            user_state,
+                            param_id,
+                            &param_name,
+                        )
                         .into_iter(),
                 );
 

--- a/egui_node_graph/src/traits.rs
+++ b/egui_node_graph/src/traits.rs
@@ -23,13 +23,14 @@ pub trait WidgetValueTrait: Default {
         &mut self,
         param_name: &str,
         node_id: NodeId,
+        param_id: InputId,
         ui: &mut egui::Ui,
         user_state: &mut Self::UserState,
         node_data: &Self::NodeData,
     ) -> Vec<Self::Response>;
 
     /// This method will be called for each input parameter with a widget with a connected
-    /// input only. To display UI for diconnected inputs use [`WidgetValueTrait::value_widget`].
+    /// input only. To display UI for disconnected inputs use [`WidgetValueTrait::value_widget`].
     /// The return value is a vector of custom response objects which can be used
     /// to implement handling of side effects. If unsure, the response Vec can
     /// be empty.
@@ -39,6 +40,7 @@ pub trait WidgetValueTrait: Default {
         &mut self,
         param_name: &str,
         _node_id: NodeId,
+        _param_id: InputId,
         ui: &mut egui::Ui,
         _user_state: &mut Self::UserState,
         _node_data: &Self::NodeData,
@@ -164,7 +166,7 @@ where
     /// Invoked between inputs, outputs and bottom UI. Useful for
     /// complicated UIs that start to lose structure without explicit
     /// separators. The `param_id` argument is the id of input or output
-    /// *preceeding* the separator.
+    /// *preceding* the separator.
     ///
     /// Default implementation does nothing.
     fn separator(
@@ -200,7 +202,7 @@ pub trait NodeTemplateIter {
 /// Used by [`NodeTemplateTrait::node_finder_categories`] to categorize nodes
 /// templates into groups.
 ///
-/// If all nodes in a program are known beforehand, it's usefult to define
+/// If all nodes in a program are known beforehand, it's useful to define
 /// an enum containing all categories and implement [`CategoryTrait`] for it. This will
 /// make it impossible to accidentally create a new category by mis-typing an existing
 /// one, like in the case of using string types.

--- a/egui_node_graph/src/traits.rs
+++ b/egui_node_graph/src/traits.rs
@@ -136,6 +136,7 @@ where
         _node_id: NodeId,
         _graph: &Graph<Self, Self::DataType, Self::ValueType>,
         _user_state: &mut Self::UserState,
+        _param_id: OutputId,
         param_name: &str,
     ) -> Vec<NodeResponse<Self::Response, Self>>
     where

--- a/egui_node_graph_example/src/app.rs
+++ b/egui_node_graph_example/src/app.rs
@@ -286,6 +286,7 @@ impl WidgetValueTrait for MyValueType {
         &mut self,
         param_name: &str,
         _node_id: NodeId,
+        _param_id: InputId,
         ui: &mut egui::Ui,
         _user_state: &mut MyGraphState,
         _node_data: &MyNodeData,


### PR DESCRIPTION
Currently, only the name is provided. I added to InputId or OutputId.
It's problematic on my side as I handle multiple many-to-many relation with multiple inputs with the same name.

**Warning** : This is a breaking change, all client code must add this parameter to these 3 methods. This would be possible to avoid that at the cost of complexity.