### PR TITLE
feat: migrate to egui 0.24

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [workspace]
-members = [
-    "egui_node_graph",
-    "egui_node_graph_example",
-]
+exclude = [ "egui_node_graph_example" ]
+members = ["egui_node_graph"]
+

--- a/egui_node_graph/Cargo.toml
+++ b/egui_node_graph/Cargo.toml
@@ -15,8 +15,8 @@ workspace = ".."
 persistence = ["serde", "slotmap/serde", "smallvec/serde", "egui/persistence"]
 
 [dependencies]
-egui = { version = "0.21.0" }
+egui = { version = "0.24.0" }
 slotmap = { version = "1.0" }
-smallvec = { version = "1.10.0" }
+smallvec = { version = "1.11.2" }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 thiserror = "1.0"

--- a/egui_node_graph/src/editor_ui.rs
+++ b/egui_node_graph/src/editor_ui.rs
@@ -810,6 +810,8 @@ where
                     .titlebar_color(ui, self.node_id, self.graph, user_state)
                     .unwrap_or_else(|| background_color.lighten(0.8)),
                 stroke: Stroke::NONE,
+                fill_texture_id: Default::default(),
+                uv: Rect::ZERO,
             });
 
             let body_rect = Rect::from_min_size(
@@ -818,9 +820,11 @@ where
             );
             let body = Shape::Rect(RectShape {
                 rect: body_rect,
-                rounding: Rounding::none(),
+                rounding: Rounding::ZERO,
                 fill: background_color,
                 stroke: Stroke::NONE,
+                fill_texture_id: Default::default(),
+                uv: Rect::ZERO,
             });
 
             let bottom_body_rect = Rect::from_min_size(
@@ -832,6 +836,8 @@ where
                 rounding,
                 fill: background_color,
                 stroke: Stroke::NONE,
+                fill_texture_id: Default::default(),
+                uv: Rect::ZERO,
             });
 
             let node_rect = titlebar_rect.union(body_rect).union(bottom_body_rect);
@@ -841,6 +847,8 @@ where
                     rounding,
                     fill: Color32::WHITE.lighten(0.8),
                     stroke: Stroke::NONE,
+                    fill_texture_id: Default::default(),
+                    uv: Rect::ZERO,
                 })
             } else {
                 Shape::Noop

--- a/egui_node_graph_example/Cargo.toml
+++ b/egui_node_graph_example/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = "1.56"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-eframe = "0.21.0"
+eframe = "0.24.0"
 egui_node_graph = { path = "../egui_node_graph" }
 anyhow = "1.0"
 serde = { version = "1.0", optional = true }


### PR DESCRIPTION
I updated egui to the latest version and also added the example in the workspace ignore since it is not really necessary to bring it to a library release